### PR TITLE
fix typo in scmd when specifying queue

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -180,8 +180,8 @@ ssub_cmd = function(script.fn, queue, jname = NULL, jlabel = NULL, jgroup = NULL
         qjerr = paste( "", names(script.fn), ".bsub.err", "", sep="" )
         qjrout = paste( "", names(script.fn), ".R.out", "", sep="" )                    
         out_cmd = paste("sbatch --export=ALL --output=", qjout, sep = '');
-        out_cmd = paste(out_cmd, ifelse(is.na(queue), '', paste("--partition=", queue)))
-        out_cmd = paste(out_cmd, '--time=',time, ':00:00 ', sep = '') 
+        out_cmd = paste(out_cmd, ifelse(is.na(queue), '', paste0("--partition=", queue)))
+        out_cmd = paste(out_cmd, paste0('--time=', time, ':00:00 '))
         if (!is.null(mem)) out_cmd = paste(out_cmd, " --mem=", mem, "G", sep = "");
         #if (!is.null(jgroup)) out_cmd = paste(out_cmd, " -g ", sub('^\\/*', '/', jgroup))
         ## if (!is.null(cwd)) out_cmd = paste(out_cmd, " --workdir=", cwd , sep = '')


### PR DESCRIPTION
previously when queue was specified, the resulting sbatch command had a typo, e.g.
```sbatch ... --partition= pe2--time=3-00:00:00 ... ```

this PR just fixes this typo so that we can have:
```sbatch ... --partition=pe2 --time=3-00:00:00 ...```